### PR TITLE
Adds support for adding arguments to PhantomJS command line

### DIFF
--- a/src/PdfGenerator.php
+++ b/src/PdfGenerator.php
@@ -45,6 +45,11 @@ class PdfGenerator
     protected $commandLineOptions = [];
 
     /**
+     * @var array
+     */
+    protected $commandLineArguments = [];
+
+    /**
      * @var string
      */
     protected $convertScript = 'generate-pdf.js';
@@ -123,7 +128,8 @@ class PdfGenerator
             implode(' ', $this->commandLineOptions),
             $this->convertScript,
             $this->prefixHtmlPath($this->htmlPath),
-            $this->pdfPath
+            $this->pdfPath,
+            implode(' ', $this->commandLineArguments),
         ]);
 
         $process = new Process($command, __DIR__);
@@ -249,6 +255,15 @@ class PdfGenerator
     public function addCommandLineOption($option)
     {
         $this->commandLineOptions[] = $option;
+    }
+
+    /**
+     * Add a command line arg for PhantomJS
+     * @param string $arg
+     */
+    public function addCommandLineArgument($arg)
+    {
+        $this->commandLineArguments[] = $arg;
     }
 
     /**


### PR DESCRIPTION
This PR allows your php code to pass additional data to the PhantomJS script. I need this feature in my app, and thought I'd submit it here to see if it would be useful for others.

Note: Additional steps or tests could be done to see how to handled encapsulating values in quotes for data with spaces? It just was not needed in my app.

```
// In you PHP code
$pdf->addCommandLineArgument('my-extra-data');
$pdf->addCommandLineArgument('my-secret');

// In Phantom JS convert script
const myExtraData = args[3];
const mySecret = args[4];
```