### PR TITLE
Ability to clear "extra" cli arguments after each run

### DIFF
--- a/src/PdfGenerator.php
+++ b/src/PdfGenerator.php
@@ -267,6 +267,14 @@ class PdfGenerator
     }
 
     /**
+     * Clear all applied command line arg for PhantomJS
+     */
+    public function clearCommandLineArguments()
+    {
+        $this->commandLineArguments = [];
+    }
+
+    /**
      * Use a custom script to be run via PhantomJS
      * @param string $path
      */


### PR DESCRIPTION
This is related to my previous PR #24, unfortunately I did not test full, as I just ran into another use case when you generate multiple pdf in the same request cycle, it may be desired to reset the arguments to add different ones.

Use case:
I just tested running in a Laravel queue, and because the worker is never killed the instance of phantom-pdf always exists. So in the next job, if I were to add "extra arguments", those args get added to the previous list, instead of replaced.

I was not sure how best to handle this scenario, based on how this package is used, direction, which the maintainer might have better feed back. I can adjust this PR or can be closed.

Solution 1: Change the new `addCommandLineArgument` method to be able to clear the arguments
```
public function addCommandLineArgument()
{
  if (func_num_args() > 0) {
    $this->commandLineArguments = is_array(func_get_arg(0)) ? func_get_arg(0) : func_get_args();
  } else {
    $this->commandLineArguments = [];
  }
}
```

Solution 2: New method to clear the extra arguments (this PR)
```
public function clearCommandLineArguments()
{
  $this->commandLineArguments = [];
}
```

Solution 3: clear arguments after every run
```
protected function generatePdf($view)
{
  // .. rest of method code

  $this->commandLineArguments = [];
}
```