### PR TITLE
Fixed support for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/http-foundation": "^6.0",
-        "symfony/process": "^6.0"
+        "symfony/http-foundation": "^6.0|^7.0",
+        "symfony/process": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I updated 2 Symfony libraries to be compatible with Laravel 11.

```json
"symfony/http-foundation": "^6.0|^7.0",
"symfony/process": "^6.0|^7.0"
```

The patch has been tested on my projects, I think it can ve safely merged.